### PR TITLE
Add kwarg for chunk length to is_binary

### DIFF
--- a/binaryornot/check.py
+++ b/binaryornot/check.py
@@ -16,9 +16,10 @@ from binaryornot.helpers import get_starting_chunk, is_binary_string
 logger = logging.getLogger(__name__)
 
 
-def is_binary(filename):
+def is_binary(filename, bytes_to_read=1024):
     """
     :param filename: File to check.
+    :param bytes_to_read: Number of bytes to read from file to perform check.
     :returns: True if it's a binary file, otherwise False.
     """
     logger.debug('is_binary: %(filename)r', locals())
@@ -30,7 +31,7 @@ def is_binary(filename):
 #             return True
 
     # Check if the starting chunk is a binary string
-    chunk = get_starting_chunk(filename)
+    chunk = get_starting_chunk(filename, length=bytes_to_read)
     return is_binary_string(chunk)
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
     install_requires=[
         'chardet>=3.0.2',
     ],
+    tests_require=[
+        'hypothesis'
+    ],
     license="BSD",
     zip_safe=False,
     keywords='binaryornot',


### PR DESCRIPTION
Added a kwarg for the number of bytes to read from a file to check to `is_binary`, which is passed along to `helpers.get_starting_chunk`. I've found that for some of the files I was checking, doubling the default to 2048 bytes improved the results of the heuristics.